### PR TITLE
Implementation of UserCreationForm to create new users

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,8 +6,9 @@
   <component name="ChangeListManager">
     <list default="true" id="bc2289a6-6f50-431d-8416-d2167537ba0d" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/public/base_templates/global/partials/_header.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/public/base_templates/global/partials/_header.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/public/contact/forms.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/public/contact/forms.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/public/contact/urls.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/public/contact/urls.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/public/contact/views/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/public/contact/views/__init__.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/public/contact/views/contact_forms.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/public/contact/views/contact_forms.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -46,22 +47,28 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Docker.docker.backend: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;Docker.docker: Compose Deployment.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;17-04&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Users/breno.pombo/projects/Django-Tutorial&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Docker.docker.backend: Compose Deployment.executor": "Run",
+    "Docker.docker: Compose Deployment.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "17-04",
+    "junie.onboarding.icon.badge.shown": "true",
+    "last_opened_file_path": "C:/Users/breno.pombo/projects/Django-Tutorial/src/public/contact/views",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
+  <component name="RecentsManager">
+    <key name="CopyFile.RECENT_KEYS">
+      <recent name="C:\Users\breno.pombo\projects\Django-Tutorial\src\public\contact\views" />
+      <recent name="C:\Users\breno.pombo\projects\Django-Tutorial\src\public\contact\templates\contact" />
+    </key>
+  </component>
   <component name="RunManager" selected="Docker.docker: Compose Deployment">
     <configuration default="true" type="docker-deploy" factoryName="docker-compose.yml" temporary="true">
       <deployment type="docker-compose.yml">
@@ -116,7 +123,8 @@
       <workItem from="1744243541881" duration="6825000" />
       <workItem from="1747668747502" duration="3471000" />
       <workItem from="1748533702126" duration="4095000" />
-      <workItem from="1748619781195" duration="2111000" />
+      <workItem from="1748619781195" duration="4396000" />
+      <workItem from="1749139226982" duration="975000" />
     </task>
     <servers />
   </component>

--- a/src/public/contact/forms.py
+++ b/src/public/contact/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth.forms import UserCreationForm
 from django.core.exceptions import ValidationError
 from .models import Contact
 
@@ -62,3 +63,7 @@ class ContactForm(forms.ModelForm):
             )
 
         return first_name
+
+
+class RegisterForm(UserCreationForm):
+    ...

--- a/src/public/contact/templates/contact/register.html
+++ b/src/public/contact/templates/contact/register.html
@@ -1,0 +1,42 @@
+{% extends 'global/base.html' %}
+
+{% block content %}
+    <div class="form-wrapper">
+        <h2>Register</h2>
+        <form
+            action="{{ form_action }}"
+            method="POST">
+            {% csrf_token %}
+            <div class="form-content">
+
+                {% for field in form %}
+                    <div class="form-group">
+                        <label for="{{ field.id_for_label }}"> {{ field.label }}</label>
+                        {{ field }}
+                        {{ field.errors}}
+
+                        {% if field.help_text %}
+                            <p class="help-text"> {{ field.help_text }}</p>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
+
+            {% if form.non_field_errors %}
+                <div class="form-content">
+                  <div class="form-group">
+                      <div class="message error">
+                          {{ form.non_field_errors}}
+                      </div>
+                  </div>
+                </div>
+            {% endif %}
+
+            <div class="form-content">
+                <div class="form-group">
+                    <button class="btn" type="submit">Send</button>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock content%}

--- a/src/public/contact/urls.py
+++ b/src/public/contact/urls.py
@@ -12,4 +12,6 @@ urlpatterns = [
     path('contact/create/', views.create, name='create'),
     path('contact/<int:contact_id>/update/', views.update, name='update'),
     path('contact/<int:contact_id>/delete/', views.delete, name='delete'),
+
+    path('user/create/', views.register, name='register'),
 ]

--- a/src/public/contact/views/__init__.py
+++ b/src/public/contact/views/__init__.py
@@ -1,2 +1,3 @@
 from .contact_forms import *
 from .contact_views import *
+from .user_forms import *

--- a/src/public/contact/views/contact_forms.py
+++ b/src/public/contact/views/contact_forms.py
@@ -38,7 +38,7 @@ def update(request, contact_id:int):
 
     contact = get_object_or_404(Contact, pk=contact_id, show=True)
     form_action = reverse('contact:update', args=(contact_id,))
-    print('aqui ->',contact_id)
+
     if request.method == 'POST':
 
         form = ContactForm(request.POST, request.FILES, instance=contact)
@@ -74,7 +74,7 @@ def delete(request, contact_id:int):
     if confirmation == 'yes':
         contact.delete()
         return redirect('contact:index')
-    print('confirmation', confirmation)
+
     return render(
         request,
         'contact/contact.html',

--- a/src/public/contact/views/user_forms.py
+++ b/src/public/contact/views/user_forms.py
@@ -1,0 +1,16 @@
+from django.shortcuts import render
+
+from ..forms import RegisterForm
+
+
+def register(request):
+
+    form = RegisterForm()
+
+    return render(
+        request,
+        'contact/register.html',
+        {
+            'form': form,
+        }
+    )


### PR DESCRIPTION
Implementation of UserCreationForm to create new users

## Summary by Sourcery

Add user registration functionality by introducing a RegisterForm, view, template, and URL, and clean up extraneous debug prints in contact views.

New Features:
- Add RegisterForm for user signup extending Django's UserCreationForm
- Implement register view to render the registration form
- Create register.html template for user signup
- Add URL route for user registration at 'user/create/'

Enhancements:
- Remove debug print statements from contact update and delete views